### PR TITLE
Add robots.txt and automated sitemap generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/generate-sitemap.mjs",
     "build": "vite build",
+    "generate:sitemap": "node scripts/generate-sitemap.mjs",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://sepic.me/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://sepic.me/</loc>
+    <lastmod>2025-09-16T08:30:44.603Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://sepic.me/CV.pdf</loc>
+    <lastmod>2025-09-16T08:30:44.603Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,40 @@
+import { writeFile } from "fs/promises"
+import { fileURLToPath } from "url"
+import { dirname, resolve } from "path"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const baseUrl = "https://sepic.me/"
+const sitemapEntries = [
+  {
+    path: "/",
+    changefreq: "monthly",
+    priority: "1.0",
+  },
+  {
+    path: "/CV.pdf",
+    changefreq: "yearly",
+    priority: "0.8",
+  },
+]
+
+const today = new Date().toISOString()
+
+const urlset = sitemapEntries
+  .map(({ path, changefreq, priority }) => {
+    const url = new URL(path, baseUrl).toString()
+
+    return `  <url>\n    <loc>${url}</loc>\n    <lastmod>${today}</lastmod>\n    <changefreq>${changefreq}</changefreq>\n    <priority>${priority}</priority>\n  </url>`
+  })
+  .join("\n")
+
+const sitemapContent =
+  `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlset}\n</urlset>\n`
+
+const outputPath = resolve(__dirname, "../public/sitemap.xml")
+
+await writeFile(outputPath, sitemapContent, "utf8")
+
+console.log(`Sitemap generated at ${outputPath}`)


### PR DESCRIPTION
## Summary
- add a robots.txt file that allows all crawlers and references the sitemap
- generate a sitemap with the homepage and CV download URLs
- run an automated sitemap generation script before each build and expose it via npm scripts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c91ec15370832291b13a5fe9be9655